### PR TITLE
updated claimable CHA tokens display to account for decimal change

### DIFF
--- a/pages/apps/the-green-room.tsx
+++ b/pages/apps/the-green-room.tsx
@@ -25,7 +25,7 @@ export default function TheGreenRoom({ data }: Props) {
   const blockHeight = data.latestBlock
   const lastClaimBlockHeight = data.lastClaim
   const unclaimedBlocks = clamp(0, 999, blockHeight - lastClaimBlockHeight)
-  const dripAmount = data.dripAmount
+  const dripAmount = data.dripAmount / 1000000
   const claimableTokens = millify(unclaimedBlocks * dripAmount)
 
   console.log({ blockHeight, lastClaimBlockHeight, unclaimedBlocks, dripAmount, claimableTokens })

--- a/pages/faucet.tsx
+++ b/pages/faucet.tsx
@@ -32,7 +32,7 @@ export default function Faucet({ data }: Props) {
   const blockHeight = data.latestBlock
   const lastClaimBlockHeight = data.lastClaim
   const unclaimedBlocks = clamp(0, 999, blockHeight - lastClaimBlockHeight)
-  const dripAmount = data.dripAmount
+  const dripAmount = data.dripAmount / 1000000
   const claimableTokens = millify(unclaimedBlocks * dripAmount)
 
 


### PR DESCRIPTION
CHA token claim page would show millions of claimable tokens when in reality that wasn't the case.

For example: it would show 4M CHA tokens available when in reality the user would only receive 4.

![Screen Shot 2024-06-19 at 2 54 33 PM](https://github.com/pointblankdev/charisma-web/assets/169100233/05d1cdeb-45ad-45b2-ba51-4e71519dc580)
