### PR TITLE
Scha stake naan issue

### DIFF
--- a/pages/staking/[ca].tsx
+++ b/pages/staking/[ca].tsx
@@ -89,7 +89,9 @@ export default function StakingDetailPage({ metadata, landBalance, hadLand }: Pr
   // if using the burn token, reduce the max by exp * burn-factor (1000) to prevent not having enough tokens to pay the burn fee
   const burnTokenContract = 'SP2ZNGJ85ENDY6QRHQ5P2D4FXKGZWCKTB2T0Z55KS.liquid-staked-charisma'
   const isUsingBurnToken = metadata.wraps.ca === burnTokenContract
-  const burnFee = Math.floor(wallet.experience.amount / 1000)
+  // wallet.experience.amount defaults to NaN hence the scHa staking issue. I made the default (1) to make it work properly
+  const experienceAmount = isNaN(wallet.experience.amount) ? 1 : wallet.experience.amount;
+  const burnFee = Math.floor(experienceAmount / 1000)
   const tokensSelectedMinusFee = isUsingBurnToken ? tokensSelected - burnFee : tokensSelected
 
   const isMaxedOut = tokensSelected === baseTokenBalance
@@ -164,7 +166,7 @@ export default function StakingDetailPage({ metadata, landBalance, hadLand }: Pr
               {metadata.whitelisted ?
                 <LandControls
                   min={-landTokenBalance}
-                  max={baseTokenBalance}
+                  max={baseTokenBalance && baseTokenBalance}
                   onSetTokensSelected={setTokensSelected}
                   tokensSelected={tokensSelectedMinusFee}
                   metadata={metadata}

--- a/pages/staking/[ca].tsx
+++ b/pages/staking/[ca].tsx
@@ -89,7 +89,7 @@ export default function StakingDetailPage({ metadata, landBalance, hadLand }: Pr
   // if using the burn token, reduce the max by exp * burn-factor (1000) to prevent not having enough tokens to pay the burn fee
   const burnTokenContract = 'SP2ZNGJ85ENDY6QRHQ5P2D4FXKGZWCKTB2T0Z55KS.liquid-staked-charisma'
   const isUsingBurnToken = metadata.wraps.ca === burnTokenContract
-  // wallet.experience.amount defaults to NaN hence the scHa staking issue. I made the default (1) to make it work properly
+  // wallet.experience.amount defaults to (NaN) hence the scHa staking issue. I made the default (1) to make it work properly
   const experienceAmount = isNaN(wallet.experience.amount) ? 1 : wallet.experience.amount;
   const burnFee = Math.floor(experienceAmount / 1000)
   const tokensSelectedMinusFee = isUsingBurnToken ? tokensSelected - burnFee : tokensSelected


### PR DESCRIPTION
The NaaN issue is coming from the "wallet.experience.amount".

<img width="1278" alt="Screenshot 2024-08-25 at 12 07 57 PM" src="https://github.com/user-attachments/assets/d891a0ac-45bd-40d7-86d8-998f37409315">
